### PR TITLE
Added redirect from /rsvp to the rsvp form

### DIFF
--- a/rsvp/rsvp.html
+++ b/rsvp/rsvp.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Redirecting...</title>
+	<meta http-equiv="refresh" content="0; url=https://airtable.com/appLMKxJKjiqcNlSg/pagtuibimlUPCjORV/form" />
+</head>
+<body>
+<p>If you are not redirected automatically, follow this <a href="https://airtable.com/appLMKxJKjiqcNlSg/pagtuibimlUPCjORV/form">link to the destination</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
###### This PR description was generated by copilot
This pull request adds a simple HTML redirect page to the `rsvp/rsvp.html` file. The page automatically redirects users to an Airtable form and provides a fallback link for manual navigation. 

Key changes:

* [`rsvp/rsvp.html`](diffhunk://#diff-f7ed02bbc1924c46eb9ef6745734a8d5cbea1bf3e81157efed788a9280fd1d7fR1-R10): Created a new HTML file that includes a meta refresh tag for automatic redirection to an Airtable form and a fallback link for users who are not redirected automatically.