### PR TITLE
Change pictures to heroicons

### DIFF
--- a/home.html
+++ b/home.html
@@ -229,7 +229,11 @@
 
 
 			<div class="bg-zinc-900 p-6 rounded-xl text-left transition-transform duration-300 hover:scale-[1.03] hover:-translate-y-2 hover:shadow-2xl w-72">
-				<img src="static/imgs/3.png" alt="Yubikey" class="w-16 h-16 mb-4 mx-auto">
+				<div class="flex items-center justify-center text-6xl mb-4">
+					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white" class="w-12 h-12">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+					</svg>
+				</div>
 				<p class="text-sm text-gray-400 font-semibold mb-1">10 HOURS</p>
 				<h3 class="text-xl font-bold mb-2 text-white">Yubikey</h3>
 				<p class="text-gray-400">Submit your project that includes a weird authentication system & functionality and get a yubikey from yubico! (USB-C or -A)</p>

--- a/home.html
+++ b/home.html
@@ -203,7 +203,13 @@
 		<div class="flex justify-center gap-6">
 
 			<div class="bg-zinc-900 p-6 rounded-xl text-left transition-transform duration-300 hover:scale-[1.03] hover:-translate-y-2 hover:shadow-2xl w-72">
-				<img src="static/imgs/1.png" alt="NFC Tags" class="w-16 h-16 mb-4 mx-auto">
+				<div class="flex items-center justify-center text-6xl mb-4">
+					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+					     stroke-width="1.5" stroke="white" class="w-12 h-12">
+						<path stroke-linecap="round" stroke-linejoin="round"
+						      d="M9.348 14.652a3.75 3.75 0 0 1 0-5.304m5.304 0a3.75 3.75 0 0 1 0 5.304m-7.425 2.121a6.75 6.75 0 0 1 0-9.546m9.546 0a6.75 6.75 0 0 1 0 9.546M5.106 18.894c-3.808-3.807-3.808-9.98 0-13.788m13.788 0c3.808 3.807 3.808 9.98 0 13.788M12 12h.008v.008H12V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+					</svg>
+				</div>
 				<p class="text-sm text-gray-400 font-semibold mb-1">4 HOURS</p>
 				<h3 class="text-xl font-bold mb-2 text-white">NFC Tags</h3>
 				<p class="text-gray-400">You can win <b>10 programmable NFC tags</b> for working 4 hours on authly</p>

--- a/home.html
+++ b/home.html
@@ -217,7 +217,11 @@
 
 
 			<div class="bg-zinc-900 p-6 rounded-xl text-left transition-transform duration-300 hover:scale-[1.03] hover:-translate-y-2 hover:shadow-2xl w-72">
-				<img src="static/imgs/2.png" alt="Antivirus" class="w-16 h-16 mb-4 mx-auto">
+				<div class="flex items-center justify-center text-6xl mb-4">
+					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white" class="w-12 h-12">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+					</svg>
+				</div>
 				<p class="text-sm text-gray-400 font-semibold mb-1">6 HOURS</p>
 				<h3 class="text-xl font-bold mb-2 text-white">1 year Antivirus</h3>
 				<p class="text-gray-400">With 6 hours on a project in authly, you can win 1 year of <a href="https://us.norton.com" class="underline text-gray-400">Norton</a> antivirus</p>


### PR DESCRIPTION
###### This PR description was generated by copilot
This pull request updates the reward cards section in `home.html` to improve visual consistency and scalability by replacing static image files with inline SVG icons for each reward. This change makes the UI more modern and easier to maintain.

Visual and UI improvements:

* Replaced the `<img>` tags referencing static images (`static/imgs/1.png`, `static/imgs/2.png`, `static/imgs/3.png`) with corresponding inline SVG icons for the NFC Tags, Antivirus, and Yubikey reward cards.
* Updated the card layout to use a flex container for centering and sizing the SVG icons, ensuring consistent appearance across all cards.