### PR TITLE
Conbine frontend & backend with Docker/Apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM docker.io/python:3.10-slim
+
+RUN apt-get update && apt-get install -y apache2 apache2-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip install mod_wsgi
+RUN mod_wsgi-express module-config > /etc/apache2/mods-available/wsgi.load
+RUN a2enmod wsgi
+
+COPY . /var/www/html/
+
+COPY idea-api/ /app/
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+COPY apache.conf /etc/apache2/sites-available/000-default.conf
+RUN chown -R www-data:www-data /app
+
+EXPOSE 80
+
+CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/apache.conf
+++ b/apache.conf
@@ -1,0 +1,17 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+
+    WSGIDaemonProcess idea-api python-path=/app
+    WSGIScriptAlias /api /app/idea_api.wsgi
+
+    <Directory /app>
+        WSGIProcessGroup idea-api
+        WSGIApplicationGroup %{GLOBAL}
+        Order deny,allow
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/idea-api/idea_api.wsgi
+++ b/idea-api/idea_api.wsgi
@@ -1,0 +1,3 @@
+import sys
+sys.path.insert(0, '/app/')
+from idea_api import app as application

--- a/idea-api/requirements.txt
+++ b/idea-api/requirements.txt
@@ -1,0 +1,3 @@
+Flask==2.0.3
+Werkzeug==2.0.3
+Flask-Limiter==2.2.0

--- a/static/js/idea-generator.js
+++ b/static/js/idea-generator.js
@@ -1,4 +1,4 @@
-const API_BASE = 'https://authlyapi2.pythonanywhere.com';
+const API_BASE = '/api';
 
 const generateBtn = document.getElementById('generateBtn');
 const ideaContainer = document.getElementById('ideaContainer');
@@ -67,22 +67,15 @@ ideaDisclaimer.hidden = true;
 let currentIdea = null;
 
 async function tryFetchWithFallback(endpoint, options = {}) {
-  const urls = [
-    `https://corsproxy.io/?${API_BASE}${endpoint}`,
-    `https://api.allorigins.win/raw?url=${API_BASE}${endpoint}`, 
-    `https://thingproxy.freeboard.io/fetch/${API_BASE}${endpoint}`
-  ];
-
-  for (const url of urls) {
-    try {
-      const res = await fetch(url, options);
-      if (res.ok) return res;
-      console.warn(`❌ Proxy responded with status ${res.status}: ${url}`);
-    } catch (err) {
-      console.warn(`❌ Failed on ${url}`, err);
-    }
+  const url = `${API_BASE}${endpoint}`;
+  try {
+    const res = await fetch(url, options);
+    if (res.ok) return res;
+    console.warn(`❌ API responded with status ${res.status}: ${url}`);
+  } catch (err) {
+    console.warn(`❌ Failed on ${url}`, err);
   }
-  throw new Error("All proxy attempts failed");
+  throw new Error("API call failed");
 }
 
 async function fetchRandomIdea() {


### PR DESCRIPTION
Authly currently has the problem of difficulties with CORS/rate limiting, given the backend used to live on PythonAnywhere. This PR adds a way to properly host Authly, and while requiring a different setup to run, it'll be a much better experience in the long run, as you won't have to deal with hosting things at two places.

The backend and frontend are accessible from the same host now, with the frontend being on `/`, and the backend on `/api`. If you need to figure out how to build the Dockerfile, you can just use this command: `docker build -t auth-ysws-app .`
To run it: `docker run -p 8080:80 auth-ysws-app`.

I'm not sure how you'd get set up on the Hack Club Coolify, but you should talk to your PoC in that case.