### PR TITLE
Add salted password instructions for Django/Flask

### DIFF
--- a/tutorial/temporary/tutorial.js
+++ b/tutorial/temporary/tutorial.js
@@ -41,7 +41,7 @@ const tutorials = [
         "code_snippets": {
             "flask": {
                 "language": "python",
-                "code": "from werkzeug.security import generate_password_hash\nhashed_pw = generate_password_hash('mypassword')"
+                "code": "from werkzeug.security import generate_password_hash, check_password_hash\nhashed_pw = generate_password_hash('mypassword')\n# Flask salts (adds random characters stored in the database) passwords\n#Use this to check it:\ncheck_password_hash(hashed_pw, 'mypassword')"
             },
             "express": {
                 "language": "javascript",
@@ -49,7 +49,7 @@ const tutorials = [
             },
             "django": {
                 "language": "python",
-                "code": "from django.contrib.auth.hashers import make_password\nhashed_pw = make_password('mypassword')"
+                "code": "from django.contrib.auth.hashers import make_password, check_password\nhashed_pw = make_password('mypassword')\n# Django salts (adds random characters stored in the database) passwords\n#Use this to check it:\ncheck_password('mypassword', hashed_pw)"
             }
         },
         "next": 4
@@ -388,3 +388,4 @@ backBtn.addEventListener('click', () => {
 });
 
 displayTutorial(currentId);
+


### PR DESCRIPTION
Django and Flask salts passwords to prevent rainbow table attacks and must be checked with a special function. I don't know how Express works so I didn't change it